### PR TITLE
[feat/#29] 리뷰 보기 네비게이션 구현

### DIFF
--- a/CUKBOB-iOS/Sources/Global/Extension/UINavigationController+.swift
+++ b/CUKBOB-iOS/Sources/Global/Extension/UINavigationController+.swift
@@ -1,0 +1,19 @@
+//
+//  UINavigationController+.swift
+//  CUKBOB-iOS
+//
+//  Created by 김승원 on 6/2/25.
+//
+
+import UIKit
+
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}

--- a/CUKBOB-iOS/Sources/Global/Extension/View+.swift
+++ b/CUKBOB-iOS/Sources/Global/Extension/View+.swift
@@ -21,3 +21,86 @@ extension View {
         background(ViewDidAppearModifier(onDidAppear: perform))
     }
 }
+
+// MARK: - Custom NavigationBar
+
+extension View {
+    @ViewBuilder
+    func customNavigationBar(_ navigationBarType: NavigationBarType) -> some View {
+        switch navigationBarType {
+        case .seeReview(let backAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        CUKBOBText("리뷰", fontType: .heading02, color: Color(.blue700))
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.arrowLeft)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: Screen.width(18), height: Screen.height(18))
+                        }
+                    },
+                    rightView: {
+                        EmptyView()
+                    },
+                    backgroundColor: Color(.blue100)
+                )
+            )
+        case .writeReview(let backAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        CUKBOBText("리뷰 작성", fontType: .heading02, color: Color(.blue700))
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.arrowLeft)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: Screen.width(18), height: Screen.height(18))
+                        }
+                    },
+                    rightView: {
+                        EmptyView()
+                    },
+                    backgroundColor: Color(.blue100)
+                )
+            )
+        case .foodAndBeverageDetail(let backAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        EmptyView()
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.arrowLeft)
+                                .renderingMode(.template)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: Screen.width(24), height: Screen.height(24))
+                                .foregroundStyle(Color(.gray0))
+                        }
+                    },
+                    rightView: {
+                        EmptyView()
+                    }
+                )
+            )
+        }
+    }
+}
+
+enum NavigationBarType {
+    case seeReview(backAction: () -> Void)
+    case writeReview(backAction: () -> Void)
+    case foodAndBeverageDetail(backAction: () -> Void)
+}

--- a/CUKBOB-iOS/Sources/Global/Extension/View+.swift
+++ b/CUKBOB-iOS/Sources/Global/Extension/View+.swift
@@ -16,22 +16,8 @@ extension View {
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
         clipShape(RoundedCorner(radius: radius, corners: corners))
     }
-}
-
-struct RoundedCorner: Shape {
-    var radius: CGFloat = .infinity
-    var corners: UIRectCorner = .allCorners
     
-    func path(in rect: CGRect) -> Path {
-        let path = UIBezierPath(
-            roundedRect: rect,
-            byRoundingCorners: corners,
-            cornerRadii: CGSize(
-                width: radius,
-                height: radius
-            )
-        )
-        
-        return Path(path.cgPath)
+    func onDidAppear(perform: @escaping () -> Void) -> some View {
+        background(ViewDidAppearModifier(onDidAppear: perform))
     }
 }

--- a/CUKBOB-iOS/Sources/Global/Extension/View+.swift
+++ b/CUKBOB-iOS/Sources/Global/Extension/View+.swift
@@ -19,6 +19,8 @@ extension View {
     
     func onDidAppear(perform: @escaping () -> Void) -> some View {
         background(ViewDidAppearModifier(onDidAppear: perform))
+            .ignoresSafeArea(edges: .bottom)
+            .background(Color(.blue100))
     }
 }
 

--- a/CUKBOB-iOS/Sources/Global/Navigation/Enum/Destination.swift
+++ b/CUKBOB-iOS/Sources/Global/Navigation/Enum/Destination.swift
@@ -11,6 +11,7 @@ public enum Destination: Hashable {
     case temp
     case nickName
     case nickNameComplete(nickName: String)
+    case seeReview
 }
 
 // MARK: - Func
@@ -25,6 +26,8 @@ extension Destination {
             NickNameView(viewModel: NickNameViewModel())
         case .nickNameComplete(let nickName):
             NickNameCompleteView(nickName: nickName)
+        case .seeReview:
+            SeeReviewView(viewModel: SeeReviewViewModel())
         }
     }
 }

--- a/CUKBOB-iOS/Sources/Global/Navigation/NavigationManager.swift
+++ b/CUKBOB-iOS/Sources/Global/Navigation/NavigationManager.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 final class NavigationManager: ObservableObject {
     
+    @Published var shouldHideTabBar: Bool = false
+    
     @Published var loginPath = NavigationPath()
     @Published var homePath = NavigationPath()
     @Published var weeklyMenuPath = NavigationPath()

--- a/CUKBOB-iOS/Sources/Global/Util/CustomNavigationBarModifier.swift
+++ b/CUKBOB-iOS/Sources/Global/Util/CustomNavigationBarModifier.swift
@@ -26,9 +26,9 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
     }
     
     func body(content: Content) -> some View {
-        VStack {
+        VStack(spacing: Screen.height(0)) {
             ZStack(alignment: .center) {
-                HStack {
+                HStack(spacing: Screen.width(0)) {
                     self.leftView?()
                     
                     Spacer()

--- a/CUKBOB-iOS/Sources/Global/Util/CustomNavigationBarModifier.swift
+++ b/CUKBOB-iOS/Sources/Global/Util/CustomNavigationBarModifier.swift
@@ -1,0 +1,52 @@
+//
+//  CustomNavigationBarModifier.swift
+//  CUKBOB-iOS
+//
+//  Created by 김승원 on 6/2/25.
+//
+
+import SwiftUI
+
+struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View, R: View {
+    let centerView: (() -> C)?
+    let leftView: (() -> L)?
+    let rightView: (() -> R)?
+    let backgroundColor: Color
+    
+    init(
+        centerView: (() -> C)? = nil,
+        leftView: (() -> L)? = nil,
+        rightView: (() -> R)? = nil,
+        backgroundColor: Color = .clear
+    ) {
+        self.centerView = centerView
+        self.leftView = leftView
+        self.rightView = rightView
+        self.backgroundColor = backgroundColor
+    }
+    
+    func body(content: Content) -> some View {
+        VStack {
+            ZStack(alignment: .center) {
+                HStack {
+                    self.leftView?()
+                    
+                    Spacer()
+                    
+                    self.rightView?()
+                }
+                
+                self.centerView?()
+                
+            }
+            .padding(.horizontal, Screen.width(20))
+            .padding(.vertical, Screen.height(19))
+            .background(backgroundColor)
+            
+            content
+            
+            Spacer()
+        }
+        .navigationBarHidden(true)
+    }
+}

--- a/CUKBOB-iOS/Sources/Global/Util/RoundedCorner.swift
+++ b/CUKBOB-iOS/Sources/Global/Util/RoundedCorner.swift
@@ -1,0 +1,26 @@
+//
+//  RoundedCorner.swift
+//  CUKBOB-iOS
+//
+//  Created by 김승원 on 6/2/25.
+//
+
+import SwiftUI
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(
+                width: radius,
+                height: radius
+            )
+        )
+        
+        return Path(path.cgPath)
+    }
+}

--- a/CUKBOB-iOS/Sources/Global/Util/ViewDidAppearModifier.swift
+++ b/CUKBOB-iOS/Sources/Global/Util/ViewDidAppearModifier.swift
@@ -1,0 +1,36 @@
+//
+//  ViewDidAppearModifier.swift
+//  CUKBOB-iOS
+//
+//  Created by 김승원 on 6/2/25.
+//
+
+import SwiftUI
+
+struct ViewDidAppearModifier: UIViewControllerRepresentable {
+    let onDidAppear: () -> Void
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        ViewDidAppearController(onDidAppear: onDidAppear)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) { }
+
+    private class ViewDidAppearController: UIViewController {
+        let onDidAppear: () -> Void
+
+        init(onDidAppear: @escaping () -> Void) {
+            self.onDidAppear = onDidAppear
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            onDidAppear()
+        }
+    }
+}

--- a/CUKBOB-iOS/Sources/Presentation/Home/Component/HomeMealCell.swift
+++ b/CUKBOB-iOS/Sources/Presentation/Home/Component/HomeMealCell.swift
@@ -19,6 +19,8 @@ struct HomeMealCell: View {
         GridItem(.flexible(), spacing: Screen.width(23), alignment: nil)
     ]
     
+    var onTap: (() -> Void)?
+    
     /*
      Todo: 아래 임시 메뉴 지우고 음식이름배열, 가격 배열 주입받기
      */
@@ -32,10 +34,12 @@ struct HomeMealCell: View {
         "배추김치또머겅ㅋㅋ"
     ]
     
+    
     // MARK: - Initializer
     
-    init(restaurant: Restaurant) {
+    init(restaurant: Restaurant, onTap: (() -> Void)? = nil) {
         self.restaurant = restaurant
+        self.onTap = onTap
     }
     
     // MARK: - body
@@ -59,7 +63,7 @@ struct HomeMealCell: View {
                     Spacer()
                     
                     Button {
-                        
+                        onTap?()
                     } label: {
                         Image(.arrowRight)
                             .resizable()

--- a/CUKBOB-iOS/Sources/Presentation/Home/HomeView.swift
+++ b/CUKBOB-iOS/Sources/Presentation/Home/HomeView.swift
@@ -69,7 +69,9 @@ private extension HomeView {
     var homeMealSection: some View {
         LazyVStack(alignment: .center, spacing: Screen.height(0), pinnedViews: [.sectionHeaders]) {
             Section(header: timeSelectSection) {
-                HomeMealCell(restaurant: .cafeBona)
+                HomeMealCell(restaurant: .cafeBona) {
+                    navigationManager.navigate(to: .seeReview)
+                }
                 HomeMealCell(restaurant: .buonpranzoNoodle)
                 HomeMealCell(restaurant: .buonpranzoRice)
                 HomeMealCell(restaurant: .cafeMensa)

--- a/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewView.swift
+++ b/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewView.swift
@@ -1,0 +1,41 @@
+//
+//  SeeReviewView.swift
+//  CUKBOB-iOS
+//
+//  Created by 김승원 on 6/2/25.
+//
+
+import SwiftUI
+
+struct SeeReviewView: View {
+    
+    // MARK: - Properties
+    
+    @EnvironmentObject var navigationManager: NavigationManager
+    @StateObject var viewModel: SeeReviewViewModel
+    
+    // MARK: - body
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            Spacer()
+        }
+        .background(.red)
+        .onDidAppear {
+            withAnimation(.easeOut(duration: 0.15)) {
+                navigationManager.shouldHideTabBar = true
+            }
+        }
+        .onDisappear {
+            withAnimation(.easeOut(duration: 0.15)) {
+                navigationManager.shouldHideTabBar = false
+            }
+        }
+    }
+}
+
+#Preview {
+    SeeReviewView(viewModel: SeeReviewViewModel())
+}

--- a/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewView.swift
+++ b/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewView.swift
@@ -17,13 +17,15 @@ struct SeeReviewView: View {
     // MARK: - body
     
     var body: some View {
-        VStack {
-            Spacer()
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-            Spacer()
+        ScrollView {
+            HStack {
+
+                Text("hello")
+                    .frame(maxWidth: .infinity)
+            }
         }
+        .background(Color(.blue100))
         .customNavigationBar(.seeReview(backAction: navigationManager.popBack))
-        .background(.red)
         .onDidAppear {
             withAnimation(.easeOut(duration: 0.15)) {
                 navigationManager.shouldHideTabBar = true

--- a/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewView.swift
+++ b/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewView.swift
@@ -22,6 +22,7 @@ struct SeeReviewView: View {
             Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
             Spacer()
         }
+        .customNavigationBar(.seeReview(backAction: navigationManager.popBack))
         .background(.red)
         .onDidAppear {
             withAnimation(.easeOut(duration: 0.15)) {

--- a/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewViewModel.swift
+++ b/CUKBOB-iOS/Sources/Presentation/Review/SeeReview/SeeReviewViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  SeeReviewViewModel.swift
+//  CUKBOB-iOS
+//
+//  Created by 김승원 on 6/2/25.
+//
+
+import Foundation
+
+final class SeeReviewViewModel: ObservableObject {
+    
+}
+
+// MARK: - Functions
+
+extension SeeReviewViewModel {
+    
+}
+

--- a/CUKBOB-iOS/Sources/Presentation/TabBar/TabBarView.swift
+++ b/CUKBOB-iOS/Sources/Presentation/TabBar/TabBarView.swift
@@ -36,7 +36,10 @@ struct TabBarView: View {
                 }
             }
             
-            CUKBOBTabBar(selectedTab: $navigationManager.selectedTab)
+            if !navigationManager.shouldHideTabBar {
+                CUKBOBTabBar(selectedTab: $navigationManager.selectedTab)
+                    .transition(.move(edge: .bottom))
+            }
         }
         .fullScreenCover(item: $navigationManager.fullScreenModal) { destination in
             destination.build()


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #29 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 리뷰보기 넘어갈 때 탭바 내려가는 거 구현했습니다
- 커스텀 네비게이션바 modifier를 구현했습니다
- 코드 길어질 거 같아서 끊고 새로 이슈 파서 작업하겠습니다

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/d9a54095-8b90-4c7a-9847-d8d49d033059" width ="250"> | <img src = "https://github.com/user-attachments/assets/7ecbe670-e20f-4e96-9e9c-ff414ef737c6" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 커스텀 네비바

- 현재 피그마에 있는 네비바 다 만들었어요
- 뷰에 모디파이어로 사용하심 됩니다
- backButton onTap 연결해야해서, 아래 코드처럼 navigationManager.popBack 연결해주셔야 합니다

```swift
.customNavigationBar(.seeReview(backAction: navigationManager.popBack))
.customNavigationBar(.writeReview(backAction: navigationManager.popBack))
.customNavigationBar(.foodAndBeverageDetail(backAction: navigationManager.popBack))
```

### 리뷰보기 뷰 넘어갈 때 탭바 사라지게

- 피그마에 리뷰보기 뷰에서 탭바가 없어서 탭바를 내리는 코드를 작성했는데
- 생각보다 쉽지 않네요
- 일단 이대로 놔두고, 디쟌쌤 qa를 기다리겠습니다..

```Swift
.onDidAppear { // <- 커스텀으로 만든 거!
    withAnimation(.easeOut(duration: 0.15)) {
        navigationManager.shouldHideTabBar = true
    }
}
.onDisappear {
    withAnimation(.easeOut(duration: 0.15)) {
        navigationManager.shouldHideTabBar = false
    }
}
```

- 이렇게 `onDidAppear` 시점과 `onDisappear` 시점에서 애니메이션 줬어요

